### PR TITLE
update steps code for pcm-webtool support

### DIFF
--- a/pycomod/elements.py
+++ b/pycomod/elements.py
@@ -437,7 +437,11 @@ class Equation(BuildingBlock):
 class Step(Equation):
 
     def __init__(self, values, times, default=0, parent=None):
-
+        
+        #add components to allow for better pcm-webtool support
+        self.values = values
+        self.times = times
+        
         # Define the step function
         def eq_func(t=0):
             


### PR DESCRIPTION
all this does is add times and values as attributes within every step function so that my pcm webtool project can extract them with:
```py
m._equations[n].values
m._equations[n].times
```
or (depending on how the step was defined)
```py
m._equations[n].values.value.tolist()
m._equations[n].times.values.tolist()
```
to return lists of values and times.
my future development of  [pcm-webtool](https://github.com/Bradinator2000/pcm-webtool) will be done with this tiny change because I can find no other way to access those lists of values and times. --- and calling <step function object>.eq_func does not return any useful information.

<img width="674" height="213" alt="Screenshot 2025-08-28 103811" src="https://github.com/user-attachments/assets/2cc61e36-21d2-4a1b-aa21-3cd48b154d91" />
